### PR TITLE
Add CORS detection and headless media hook

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -53,5 +53,9 @@
     "activeTab",
     "scripting",
     "tabCapture",
-    "notifications" ]
+    "notifications" ],
+  "web_accessible_resources": [{
+    "resources": ["offscreen.html", "offscreen.js"],
+    "matches": ["<all_urls>"]
+  }]
 }

--- a/offscreen.html
+++ b/offscreen.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+</head>
+<body>
+<script src="offscreen.js"></script>
+</body>
+</html>

--- a/offscreen.js
+++ b/offscreen.js
@@ -1,0 +1,20 @@
+let audioElem;
+
+chrome.runtime.onMessage.addListener(async (request) => {
+  if (request.cmd === 'offscreen_play') {
+    if (!audioElem) {
+      audioElem = new Audio();
+      audioElem.crossOrigin = 'anonymous';
+    }
+    audioElem.src = request.src;
+    try {
+      audioElem.currentTime = request.currentTime || 0;
+    } catch(e) {}
+    try {
+      await audioElem.play();
+    } catch (e) {
+      console.error('Offscreen play failed', e);
+    }
+  }
+});
+


### PR DESCRIPTION
## Summary
- hook media element play in main world so headless audio/video gets appended and can be captured
- detect cross-origin media before recording and notify background
- add offscreen document to play CORS sources
- wire background listener to send commands to offscreen page
- expose the offscreen resources in manifest

## Testing
- `node --check background.js`
- `node --check src/content.js`
- `node --check offscreen.js`


------
https://chatgpt.com/codex/tasks/task_e_6870fb417ed083269d7172600a68df5e