### PR TITLE
Improve CORS handling for media capture

### DIFF
--- a/background.js
+++ b/background.js
@@ -394,17 +394,18 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
                 g_recognizer_client.clear_history();
             }
             break;
-        case "create_offscreen_element":
-            const a = new Audio();
-            a.crossOrigin = 'anonymous';
-            a.src = request.src;
-            a.currentTime = request.time || 0;
-            a.preload = 'auto';
-            corsElements[request.src] = a;
-            a.addEventListener('canplay', () => {
-                a.play().catch(() => {});
+        case "create_offscreen_element": {
+            const offscreenAudio = new Audio();
+            offscreenAudio.crossOrigin = 'anonymous';
+            offscreenAudio.src = request.src;
+            offscreenAudio.currentTime = request.time || 0;
+            offscreenAudio.preload = 'auto';
+            corsElements[request.src] = offscreenAudio;
+            offscreenAudio.addEventListener('canplay', () => {
+                offscreenAudio.play().catch(() => {});
             }, { once: true });
             break;
+        }
         case "popup_error_relay":
                         request.cmd = "popup_error";
             chrome.runtime.sendMessage(request);

--- a/background.js
+++ b/background.js
@@ -15,6 +15,7 @@ chrome.runtime.onInstalled.addListener(function(details) {
 
 var extensionConfig = {};
 var storageCache = {};
+var corsElements = {};
 function StorageHelper() {
 
     var _is_sync = false;
@@ -393,8 +394,19 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
                 g_recognizer_client.clear_history();
             }
             break;
+        case "create_offscreen_element":
+            const a = new Audio();
+            a.crossOrigin = 'anonymous';
+            a.src = request.src;
+            a.currentTime = request.time || 0;
+            a.preload = 'auto';
+            corsElements[request.src] = a;
+            a.addEventListener('canplay', () => {
+                a.play().catch(() => {});
+            }, { once: true });
+            break;
         case "popup_error_relay":
-			request.cmd = "popup_error";
+                        request.cmd = "popup_error";
             chrome.runtime.sendMessage(request);
             break;
         case "popup_message_relay":

--- a/background.js
+++ b/background.js
@@ -406,6 +406,16 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
             }, { once: true });
             break;
         }
+        case "check_cors_redirect": {
+            fetch(request.src, { method: 'HEAD', redirect: 'follow' })
+                .then(resp => {
+                    const original = new URL(request.src).origin;
+                    const finalOrigin = new URL(resp.url).origin;
+                    sendResponse({ crossOrigin: finalOrigin !== original });
+                })
+                .catch(() => sendResponse({ crossOrigin: false }));
+            return true;
+        }
         case "popup_error_relay":
                         request.cmd = "popup_error";
             chrome.runtime.sendMessage(request);

--- a/src/content.js
+++ b/src/content.js
@@ -116,8 +116,11 @@ function audioRecorderFirefox() {
                                                 if (elemOrigin !== document.location.origin) {
                                                         return true;
                                                 }
-                                                const resp = await fetch(src, { method: 'HEAD' });
-                                                return resp.type === 'opaque' || resp.type === 'opaqueredirect';
+                                                const resp = await chrome.runtime.sendMessage({
+                                                        cmd: 'check_cors_redirect',
+                                                        src
+                                                });
+                                                return resp && resp.crossOrigin;
                                         } catch (e) {
                                                 return false;
                                         }


### PR DESCRIPTION
## Summary
- hook HTMLMediaElement play calls in page context so headless media is appended
- add `isCorsSource` check to detect CORS-protected sources and notify background
- background script now creates an offscreen element for CORS media

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb417ed083269d7172600a68df5e