### PR TITLE
Improve CORS handling for media capture

### DIFF
--- a/background.js
+++ b/background.js
@@ -393,8 +393,18 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
                 g_recognizer_client.clear_history();
             }
             break;
+        case "check_cors_redirect": {
+            fetch(request.src, { method: 'HEAD', redirect: 'follow' })
+                .then(resp => {
+                    const original = new URL(request.src).origin;
+                    const finalOrigin = new URL(resp.url).origin;
+                    sendResponse({ crossOrigin: finalOrigin !== original });
+                })
+                .catch(() => sendResponse({ crossOrigin: false }));
+            return true;
+        }
         case "popup_error_relay":
-			request.cmd = "popup_error";
+                        request.cmd = "popup_error";
             chrome.runtime.sendMessage(request);
             break;
         case "popup_message_relay":


### PR DESCRIPTION
## Summary
- hook HTMLMediaElement play calls so hidden elements are added to the page
- detect redirected CORS sources from the background script
- create and sync a muted off‑screen clone when CORS media is detected
- record from the clone while keeping the original audio audible
- remove unused background code

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6870fb417ed083269d7172600a68df5e