### PR TITLE
Implement CORS-aware recording

### DIFF
--- a/src/headless-hook.js
+++ b/src/headless-hook.js
@@ -1,0 +1,9 @@
+(function(){
+    const origPlay = HTMLMediaElement.prototype.play;
+    HTMLMediaElement.prototype.play = function(...args){
+        if(!this.isConnected){
+            try{ (document.body || document.documentElement).appendChild(this); }catch(e){}
+        }
+        return origPlay.apply(this, args);
+    };
+})();


### PR DESCRIPTION
## Summary
- hook HTMLMediaElement.play in main page to expose headless elements
- detect CORS sources before recording
- offload CORS audio capture to the background script

## Testing
- `node -c src/content.js`
- `node -c background.js`

------
https://chatgpt.com/codex/tasks/task_e_68713daf3cb48326b06e5530353691fb