### PR TITLE
Implement CORS handling merge

### DIFF
--- a/background.js
+++ b/background.js
@@ -232,6 +232,34 @@ chrome.windows.onRemoved.addListener(function(windowId) {
 
 let noMediaFrames = 0;
 let totalFrames = 0;
+// cache blob URLs for CORS elements so we can reuse them
+var corsElements = {};
+
+async function offscreenCapture(src, currentTime, duration) {
+    try {
+        const response = await fetch(src);
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+        const audio = new Audio();
+        audio.src = url;
+        audio.crossOrigin = "anonymous";
+        audio.currentTime = currentTime || 0;
+        await audio.play();
+        const stream = audio.captureStream ? audio.captureStream() : audio.mozCaptureStream();
+        const recorder = new MediaRecorder(stream, {mimeType: "audio/webm", audioBitsPerSecond: 128000});
+        let chunks = [];
+        recorder.ondataavailable = e => { if (e.data && e.data.size > 0) chunks.push(e.data); };
+        recorder.start();
+        await new Promise(r => setTimeout(r, duration));
+        recorder.stop();
+        await new Promise(r => recorder.onstop = r);
+        const recBlob = new Blob(chunks, {type: "audio/webm"});
+        chrome.runtime.sendMessage({cmd: "firefox_ondataavailable", result: {status: 0, data: recBlob}});
+        URL.revokeObjectURL(url);
+    } catch (err) {
+        chrome.runtime.sendMessage({cmd: "firefox_ondataavailable", result: {status: -1, data: err.message}});
+    }
+}
 
 
 chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
@@ -393,8 +421,45 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
                 g_recognizer_client.clear_history();
             }
             break;
+        case "offscreen_capture":
+            offscreenCapture(request.src, request.currentTime, request.duration);
+            break;
+        case "create_offscreen_element": {
+            const existing = corsElements[request.src];
+            if (existing) {
+                sendResponse({ blobUrl: existing });
+                return true;
+            }
+            fetch(request.src)
+                .then(resp => resp.blob())
+                .then(blob => {
+                    const url = URL.createObjectURL(blob);
+                    corsElements[request.src] = url;
+                    sendResponse({ blobUrl: url });
+                })
+                .catch(() => sendResponse({ blobUrl: null }));
+            return true;
+        }
+        case "revoke_offscreen_element": {
+            const url = corsElements[request.src];
+            if (url) {
+                URL.revokeObjectURL(url);
+                delete corsElements[request.src];
+            }
+            break;
+        }
+        case "check_cors_redirect": {
+            fetch(request.src, { method: 'HEAD', redirect: 'follow' })
+                .then(resp => {
+                    const original = new URL(request.src).origin;
+                    const finalOrigin = new URL(resp.url).origin;
+                    sendResponse({ crossOrigin: finalOrigin !== original });
+                })
+                .catch(() => sendResponse({ crossOrigin: false }));
+            return true;
+        }
         case "popup_error_relay":
-			request.cmd = "popup_error";
+                        request.cmd = "popup_error";
             chrome.runtime.sendMessage(request);
             break;
         case "popup_message_relay":

--- a/src/headless-hook.js
+++ b/src/headless-hook.js
@@ -1,0 +1,12 @@
+(function(){
+    const origPlay = HTMLMediaElement.prototype.play;
+    HTMLMediaElement.prototype.play = function(...args){
+        if(!this.isConnected){
+            try{
+                this.style.display = 'none';
+                (document.documentElement || document.body).appendChild(this);
+            }catch(e){}
+        }
+        return origPlay.apply(this, args);
+    };
+})();


### PR DESCRIPTION
## Summary
- cache blob URLs for CORS elements and provide helpers to create/revoke them
- expose helpers in background script for CORS detection and clone creation
- use offscreen clones when possible and fall back to background capture
- hook headless media elements and clean up cloned elements on stop

## Testing
- `node -c src/content.js`
- `node -c background.js`

------
https://chatgpt.com/codex/tasks/task_e_68713daf3cb48326b06e5530353691fb