### PR TITLE
Improve CORS detection for radio.garden

### DIFF
--- a/background.js
+++ b/background.js
@@ -450,9 +450,11 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
                 .then(resp => {
                     const original = new URL(request.src).origin;
                     const finalOrigin = new URL(resp.url).origin;
-                    sendResponse({ crossOrigin: finalOrigin !== original });
+                    const statusOk = resp.status >= 200 && resp.status < 300;
+                    // Treat any non-OK status or origin change as cross origin.
+                    sendResponse({ crossOrigin: !statusOk || finalOrigin !== original });
                 })
-                .catch(() => sendResponse({ crossOrigin: false }));
+                .catch(() => sendResponse({ crossOrigin: true }));
             return true;
         }
         case "offscreen_capture":

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "default_locale": "en",
   "manifest_version": 3,
   "author": "app@audd.io",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "browser_specific_settings": {
     "gecko": {
       "id": "firefox@audd.tech",


### PR DESCRIPTION
## Summary
- handle failed HEAD requests as CORS sources
- bump version to 3.2.5

## Testing
- `curl -I https://radio.garden/api/ara/content/listen/8BdpbCek -L -o /dev/null -w '%{http_code} %{url_effective}\n'`

------
https://chatgpt.com/codex/tasks/task_e_687579e4c9e08326b9afe3b4d4564d37