### PR TITLE
Fix radio garden audio detection

### DIFF
--- a/background.js
+++ b/background.js
@@ -445,16 +445,6 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
             }
             break;
         }
-        case "check_cors_redirect": {
-            fetch(request.src, { method: 'HEAD', redirect: 'follow' })
-                .then(resp => {
-                    const original = new URL(request.src).origin;
-                    const finalOrigin = new URL(resp.url).origin;
-                    sendResponse({ crossOrigin: finalOrigin !== original });
-                })
-                .catch(() => sendResponse({ crossOrigin: false }));
-            return true;
-        }
         case "offscreen_capture":
             offscreenCapture(request.src, request.currentTime, request.duration);
             break;

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -150,13 +150,12 @@ function RecognizerController(popup_view) {
                 request.cmd === "start_recording") {
                 _is_starting = false;
             }
-			if (
-				request.cmd === "frame_no_media" ||
-				request.cmd === "create_offscreen_element" ||
-				request.cmd === "revoke_offscreen_element" ||
-				request.cmd === "check_cors_redirect" ||
-				request.cmd === "offscreen_capture"
-			) {
+                        if (
+                                request.cmd === "frame_no_media" ||
+                                request.cmd === "create_offscreen_element" ||
+                                request.cmd === "revoke_offscreen_element" ||
+                                request.cmd === "offscreen_capture"
+                        ) {
 				console.log("Ignoring cmd in popup:", request.cmd, request);
 				return;
 			}


### PR DESCRIPTION
## Summary
- improve audio CORS detection without HEAD requests
- fallback to offscreen clone if reloading fails
- remove unused check_cors_redirect messages

## Testing
- `node -c src/content.js`
- `node -c background.js`
- `node -c src/popup/popup.js`


------
https://chatgpt.com/codex/tasks/task_e_687579e4c9e08326b9afe3b4d4564d37