### PR TITLE
Fix audio capture on radio.garden

### DIFF
--- a/background.js
+++ b/background.js
@@ -452,7 +452,12 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
                     const finalOrigin = new URL(resp.url).origin;
                     sendResponse({ crossOrigin: finalOrigin !== original });
                 })
-                .catch(() => sendResponse({ crossOrigin: false }));
+                .catch(() => {
+                    // If the HEAD request fails (e.g. method not allowed or
+                    // blocked by CORS), assume the source is cross-origin so
+                    // we can fall back to the safer offscreen capture logic.
+                    sendResponse({ crossOrigin: true });
+                });
             return true;
         }
         case "offscreen_capture":

--- a/src/content.js
+++ b/src/content.js
@@ -141,7 +141,10 @@ function audioRecorderFirefox() {
                                         });
                                         return resp && resp.crossOrigin;
                                     } catch (e) {
-                                        return false;
+                                        // When in doubt (e.g. fetch failed), assume it's
+                                        // a cross-origin source so the safer offscreen
+                                        // capture path is used.
+                                        return true;
                                     }
                                 },
 


### PR DESCRIPTION
## Summary
- better fallback logic for CORS detection
- assume cross-origin when HEAD request fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687579e4c9e08326b9afe3b4d4564d37