### PR TITLE
Improve CORS handling for radio.garden

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "default_locale": "en",
   "manifest_version": 3,
   "author": "app@audd.io",
-  "version": "3.2.4",
+  "version": "3.2.6",
   "browser_specific_settings": {
     "gecko": {
       "id": "firefox@audd.tech",


### PR DESCRIPTION
## Summary
- follow redirects when downloading audio for offscreen capture
- expose final redirected URL to content script
- create offscreen clones using the redirected URL when available
- bump version to 3.2.6

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687579e4c9e08326b9afe3b4d4564d37