### PR TITLE
Improve CORS detection for radio.garden

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "default_locale": "en",
   "manifest_version": 3,
   "author": "app@audd.io",
-  "version": "3.2.4",
+  "version": "3.2.6",
   "browser_specific_settings": {
     "gecko": {
       "id": "firefox@audd.tech",

--- a/src/content.js
+++ b/src/content.js
@@ -129,12 +129,26 @@ function audioRecorderFirefox() {
 				},
                                 async isCorsSource(m_elm) {
                                     try {
-                                        const src = m_elm.currentSrc || m_elm.src;
+                                        let src = m_elm.currentSrc || m_elm.src;
                                         if (!src) return false;
-                                        const elemOrigin = new URL(src, document.baseURI).origin;
+                                        let elemOrigin = new URL(src, document.baseURI).origin;
                                         if (elemOrigin !== document.location.origin) {
                                             return true;
                                         }
+
+                                        await new Promise(resolve => {
+                                            if (m_elm.readyState >= 2) {
+                                                resolve();
+                                            } else {
+                                                m_elm.addEventListener('loadedmetadata', resolve, { once: true });
+                                            }
+                                        });
+                                        src = m_elm.currentSrc || m_elm.src;
+                                        elemOrigin = new URL(src, document.baseURI).origin;
+                                        if (elemOrigin !== document.location.origin) {
+                                            return true;
+                                        }
+
                                         const resp = await chrome.runtime.sendMessage({
                                             cmd: 'check_cors_redirect',
                                             src


### PR DESCRIPTION
## Summary
- handle cross origin streams in background offscreen capture
- wait for `loadedmetadata` to detect redirected origins
- bump version to 3.2.6

## Testing
- `web-ext lint`


------
https://chatgpt.com/codex/tasks/task_e_687579e4c9e08326b9afe3b4d4564d37