### PR TITLE
Improve CORS detection for radio.garden

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "default_locale": "en",
   "manifest_version": 3,
   "author": "app@audd.io",
-  "version": "3.2.4",
+  "version": "3.2.6",
   "browser_specific_settings": {
     "gecko": {
       "id": "firefox@audd.tech",


### PR DESCRIPTION
## Summary
- return final redirect URL in CORS check
- use returned URL when cloning or capturing cross origin media
- bump extension version to 3.2.6

## Testing
- ❌ `web-ext lint --source-dir=.` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687579e4c9e08326b9afe3b4d4564d37