### PR TITLE
Fix cross-origin audio detection for radio.garden

### DIFF
--- a/background.js
+++ b/background.js
@@ -446,7 +446,12 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
             break;
         }
         case "check_cors_redirect": {
-            fetch(request.src, { method: 'HEAD', redirect: 'follow' })
+            fetch(request.src, {
+                method: 'GET',
+                headers: { 'Range': 'bytes=0-0' },
+                redirect: 'follow',
+                mode: 'no-cors'
+            })
                 .then(resp => {
                     const original = new URL(request.src).origin;
                     const finalOrigin = new URL(resp.url).origin;


### PR DESCRIPTION
## Summary
- improve detection of cross-origin media redirects
- fall back to offscreen capture when CORS reload fails

## Testing
- `node --check src/content.js`
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_687694be144883269e80d9e77f9d357d