### PR TITLE
Remove templating library

### DIFF
--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -79,7 +79,7 @@
     </div>
 </body>
 
-<script id="music_info_template" type="text/x-handlebars-template">
+<script id="music_info_template" type="text/template">
     
 	<div class="cover-content {{^SquereCover}}not_squere{{/SquereCover}}">
 		<img id="initial_screen_album" src={{albumImage}} class="found" />
@@ -121,9 +121,9 @@
 			<div class="history-shadow"></div>
 			<div class="history-shadow upper-shadow"></div>
 		</div>
-	</div>
+        </div>
 </script>
-<script id="no_results_template" type="text/x-handlebars-template">
+<script id="no_results_template" type="text/template">
 	<div class="cover-content-no-results">
 		<div class="no-results-header"><div></div>
 			<h1 class="no-results-text">{{noMatchesText}}</h1>
@@ -150,9 +150,9 @@
 	<div class="scroll-shadows">
 		<div class="history-shadow no-results"></div>
 		<div class="history-shadow no-results upper-shadow"></div>
-	</div>
+        </div>
 </script>
-<script id="show_error_template" type="text/x-handlebars-template">
+<script id="show_error_template" type="text/template">
 	<div class="cover-content-show-error">
 	</div>
 	<div class="bottom-content show-error" id="bottom-content">
@@ -175,10 +175,10 @@
 	<div class="scroll-shadows">
 		<div class="history-shadow"></div>
 		<div class="history-shadow upper-shadow"></div>
-	</div>
+        </div>
 </script>
 
-<script id="list_template" type="text/x-handlebars-template">
+<script id="list_template" type="text/template">
 	<div id="history-results">
 	{{#history}}
 	<a href="{{song_link}}" target="_blank"> <div class="history-track">
@@ -188,7 +188,7 @@
 	  <div class="history-title">{{title}}</div>
 	</div></div></a>
 	{{/history}}
-	</div>
+        </div>
 </script>
 <!--<script id="list_template" type="text/x-handlebars-template">
     {{#history}}
@@ -215,7 +215,6 @@
 </script>-->
 
 <script type="text/javascript" src="vendor/jquery.min.js"></script>
-<script type="text/javascript" src="vendor/mustache.min.js"></script>
 <script type="text/javascript" src="popup.js"></script>
 <script type="text/javascript" src="canvas.js"></script>
 </html>


### PR DESCRIPTION
## Summary
- drop Mustache from popup.html and use script-based templates
- update popup.js to safely parse templates and update DOM without innerHTML
- add callback to setContent and guard against null
- delay setContent callbacks until after DOM paint
- fix identifiedEarlierText by preventing template HTML parsing

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68776762a3ac8326b7c68ea95ca8eb2a