### PR TITLE
Add consent screen

### DIFF
--- a/background.js
+++ b/background.js
@@ -319,30 +319,6 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
 				//		email = user_info["email"];
 				//		google_id = user_info["id"];
 				}
-				var a = function(key, str) {
-					str = atob(str);
-					var s = [], j = 0, x, res = '';
-					for (var i = 0; i < 256; i++) {
-						s[i] = i;
-					}
-					for (i = 0; i < 256; i++) {
-						j = (j + s[i] + key.charCodeAt(i % key.length)) % 256;
-						x = s[i];
-						s[i] = s[j];
-						s[j] = x;
-					}
-					i = 0;
-					j = 0;
-					for (var y = 0; y < str.length; y++) {
-						i = (i + 1) % 256;
-						j = (j + s[i]) % 256;
-						x = s[i];
-						s[i] = s[j];
-						s[j] = x;
-						res += String.fromCharCode(str.charCodeAt(y) ^ s[(s[i] + s[j]) % 256]);
-					}
-					return btoa(res);
-				};
 				var info = {
 				"tab_url": tab_url,
 				"email": email,

--- a/background.js
+++ b/background.js
@@ -263,8 +263,10 @@ async function offscreenCapture(src, currentTime, duration) {
 
 
 chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
-	console.log(request);
-    switch (request.cmd) {
+        console.log(request);
+        chrome.storage.local.get('consent', function(data){
+            if(!data.consent) return;
+            switch (request.cmd) {
 		/*case "query-active-tab":
             chrome.tabs.query({active: true}, (tabs) => {
                 if (tabs.length > 0) {
@@ -463,9 +465,10 @@ chrome.runtime.onMessage.addListener( function(request, sender, sendResponse) {
             chrome.runtime.sendMessage(request);
             break;
         case "popup_message_relay":
-			request.cmd = "popup_message";
+                        request.cmd = "popup_message";
             chrome.runtime.sendMessage(request);
             break;
     }
 
+        });
 });

--- a/src/content.js
+++ b/src/content.js
@@ -390,4 +390,8 @@ function audioRecorderFirefox() {
     return [];
 }
 
-audioRecorderFirefox();
+chrome.storage.local.get('consent', function(data) {
+    if (data.consent) {
+        audioRecorderFirefox();
+    }
+});

--- a/src/content.js
+++ b/src/content.js
@@ -390,8 +390,4 @@ function audioRecorderFirefox() {
     return [];
 }
 
-chrome.storage.local.get('consent', function(data) {
-    if (data.consent) {
-        audioRecorderFirefox();
-    }
-});
+audioRecorderFirefox();

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -48,6 +48,7 @@ body {
     width: 100%;
     position: absolute;
     z-index: 1;
+    text-align: justify;
 }
 
 #consent_screen .consent-content {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -43,6 +43,10 @@ body {
     padding: 15px;
     color: white;
     overflow-y: auto;
+    height: 100%;
+    width: 100%;
+    position: absolute;
+    z-index: 1;
 }
 
 #consent_screen p {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -41,12 +41,18 @@ body {
 
 #consent_screen {
     padding: 15px;
-    color: white;
+    color: #333;
+    background: white;
     overflow-y: auto;
     height: 100%;
     width: 100%;
     position: absolute;
     z-index: 1;
+}
+
+#consent_screen h1 {
+    font-size: 18px;
+    margin-top: 0;
 }
 
 #consent_screen p {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -50,19 +50,33 @@ body {
     z-index: 1;
 }
 
+#consent_screen .consent-content {
+    max-width: 270px;
+    margin: 0 auto;
+}
+
+#consent_screen a {
+    color: #315EFF;
+}
+
 #consent_screen h1 {
     font-size: 18px;
-    margin-top: 0;
+    margin: 0 0 10px;
+    text-align: center;
 }
 
 #consent_screen p {
     font-size: 14px;
     line-height: 1.4;
+    margin: 0 0 10px;
 }
 
 #consent_screen .consent-buttons {
     margin-top: 15px;
     text-align: center;
+}
+#consent_screen button {
+    min-width: 100px;
 }
 
 /* HEADER/MESSAGES */

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -39,6 +39,22 @@ body {
     display: none;
 }
 
+#consent_screen {
+    padding: 15px;
+    color: white;
+    overflow-y: auto;
+}
+
+#consent_screen p {
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+#consent_screen .consent-buttons {
+    margin-top: 15px;
+    text-align: center;
+}
+
 /* HEADER/MESSAGES */
 
 #main_header {

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -51,8 +51,8 @@ body {
 }
 
 #consent_screen .consent-content {
-    max-width: 270px;
-    margin: 0 auto;
+    max-width: 260px;
+    margin: 0;
 }
 
 #consent_screen a {
@@ -66,16 +66,16 @@ body {
 }
 
 #consent_screen p {
-    font-size: 14px;
+    font-size: 13px;
     line-height: 1.4;
     margin: 0 0 10px;
 }
 
 #consent_screen .consent-buttons {
-    margin-top: 15px;
     text-align: center;
 }
 #consent_screen button {
+    margin-top: 10px;
     min-width: 100px;
 }
 
@@ -1318,9 +1318,9 @@ canvas#canvas {
 .button.button--secondary {
     color: var(--ifm-color-gray-100);
 }
-.button.button--secondary:not(.button--active):not(:hover):not(:focus):not(.focus-visible) {
+/*.button.button--secondary:not(.button--active):not(:hover):not(:focus):not(.focus-visible) {
     color: var(--ifm-color-gray-900);
-}
+}*/
 
 .bottom-content {
     position: relative;  

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -61,8 +61,8 @@ body {
 }
 
 #consent_screen h1 {
-    font-size: 18px;
-    margin: 0 0 10px;
+    font-size: 20px;
+    margin: 0 0 15px;
     text-align: center;
 }
 
@@ -77,7 +77,7 @@ body {
 }
 #consent_screen button {
     margin-top: 10px;
-    min-width: 100px;
+    /*min-width: 100px;*/
 }
 
 /* HEADER/MESSAGES */

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -33,8 +33,8 @@
             <div id="consent_screen" class="screen">
                 <div class="consent-content">
                     <h1>Consent Required</h1>
-                    <p>AudD, LLC certifies that the data processed by the extension and by AudD is not used or transferred for purposes that are unrelated to the extension's core functionality, which is music recognition.</p>
-                    <p>When invoked, the extension records up to 12 seconds of audio that's playing on the current browser tab in order to submit it to AudD (music recognition API). The audio is transmitted to AudD servers for music identification. The audio is not stored after the music recognition is complete. AudD might store digital fingerprints of the audio for up to two weeks. The extension, together with the audio, will send its version, the tab title, and the tab URL to AudD. AudD does not share that data with third parties and uses it to prevent abuse of the music recognition API that it provides.</p>
+                    <p>Firefox requires us to show you this consent screen, even though we don't think it is neccessary, as the data processed is not used or transferred for purposes that are unrelated to the extension's core functionality.</p>
+                    <p>When invoked, the extension records up to 12 seconds of audio that's playing on the current browser tab in order to submit it to AudD (music recognition API). The audio is transmitted to AudD servers for music identification. The audio is not stored after the music recognition is complete. AudD might store digital fingerprints of the audio for up to two weeks. The extension, together with the audio, will send its version, the tab title, and the tab URL to AudD; AudD does not share that data with third parties and uses it solely to prevent abuse.</p>
                     <p><a href="https://addons.mozilla.org/en-US/firefox/addon/audd/privacy/" target="_blank">Privacy Policy</a></p>
                     <div class="consent-buttons">
                         <button id="consent_accept" class="button button--outline button--primary">Accept</button>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -12,8 +12,8 @@
         <div id="main_content">
             <img class="up_button up_right_button" id="settings_button" show-on show-on-initial src="../../icons/Settings.svg" />
             <img class="up_button up_left_button" button-initial show-on show-on-lyrics show-on-settings src="../../icons/Arrow.svg" style="display:none;"/>
+            <canvas id="canvas"></canvas>
             <div id="initial_screen" class="screen">
-                <canvas id="canvas"></canvas>
                 <div class="audio-bands">
                     <img class="audio-band big 0" src="../../img/audio-band.png" />
                     <img class="audio-band med 1" src="../../img/audio-band.png" />
@@ -37,7 +37,7 @@
                     <p>When invoked, the extension records up to 12 seconds of audio that's playing on the current browser tab in order to submit it to AudD (music recognition API). The audio is transmitted to AudD servers for music identification. The audio is not stored after the music recognition is complete. AudD might store digital fingerprints of the audio for up to two weeks. The extension, together with the audio, will send its version, the tab title, and the tab URL to AudD. AudD does not share that data with third parties and uses it to prevent abuse of the music recognition API that it provides.</p>
                     <p><a href="https://addons.mozilla.org/en-US/firefox/addon/audd/privacy/" target="_blank">Privacy Policy</a></p>
                     <div class="consent-buttons">
-                        <button id="consent_accept" class="button button--primary">Accept</button>
+                        <button id="consent_accept" class="button button--outline button--primary">Accept</button>
                         <button id="consent_reject" class="button button--outline" style="margin-left:10px;">Reject &amp; Uninstall</button>
                     </div>
                 </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -12,8 +12,8 @@
         <div id="main_content">
             <img class="up_button up_right_button" id="settings_button" show-on show-on-initial src="../../icons/Settings.svg" />
             <img class="up_button up_left_button" button-initial show-on show-on-lyrics show-on-settings src="../../icons/Arrow.svg" style="display:none;"/>
-            <canvas id="canvas"></canvas>
             <div id="initial_screen" class="screen">
+				<canvas id="canvas"></canvas>
                 <div class="audio-bands">
                     <img class="audio-band big 0" src="../../img/audio-band.png" />
                     <img class="audio-band med 1" src="../../img/audio-band.png" />
@@ -38,7 +38,7 @@
                     <p><a href="https://addons.mozilla.org/en-US/firefox/addon/audd/privacy/" target="_blank">Privacy Policy</a></p>
                     <div class="consent-buttons">
                         <button id="consent_accept" class="button button--outline button--primary">Accept</button>
-                        <button id="consent_reject" class="button button--outline" style="margin-left:10px;">Reject &amp; Uninstall</button>
+                        <button id="consent_reject" class="button button--outline button--secondary" style="margin-left:10px;">Reject &amp; Uninstall</button>
                     </div>
                 </div>
             </div>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,10 +10,10 @@
             <h1></h1>
         </div>
         <div id="main_content">
+            <canvas id="canvas"></canvas>
             <img class="up_button up_right_button" id="settings_button" show-on show-on-initial src="../../icons/Settings.svg" />
             <img class="up_button up_left_button" button-initial show-on show-on-lyrics show-on-settings src="../../icons/Arrow.svg" style="display:none;"/>
             <div id="initial_screen" class="screen">
-				<div><canvas id="canvas" /></div>
                 <div class="audio-bands">
                     <img class="audio-band big 0" src="../../img/audio-band.png" />
                     <img class="audio-band med 1" src="../../img/audio-band.png" />

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -30,6 +30,17 @@
 					<div id="footer_msg"></div>
 				</div>
             </div>
+            <div id="consent_screen" class="screen">
+                <div class="consent-content">
+                    <p>AudD, LLC certifies that the data processed by the extension and by AudD is not used or transferred for purposes that are unrelated to the extension's core functionality, which is music recognition.</p>
+                    <p>When invoked, the extension records up to 12 seconds of audio that's playing on the current browser tab in order to submit it to AudD (music recognition API). The audio is transmitted to AudD servers for music identification. The audio is not stored after the music recognition is complete. AudD might store digital fingerprints of the audio for up to two weeks. The extension, together with the audio, will send its version, the tab title, and the tab URL to AudD. AudD does not share that data with third parties and uses it to prevent abuse of the music recognition API that it provides.</p>
+                    <p><a href="https://addons.mozilla.org/en-US/firefox/addon/audd/privacy/" target="_blank">Privacy Policy</a></p>
+                    <div class="consent-buttons">
+                        <button id="consent_accept" class="button button--primary">Accept</button>
+                        <button id="consent_reject" class="button button--outline" style="margin-left:10px;">Reject &amp; Uninstall</button>
+                    </div>
+                </div>
+            </div>
             <div id="settings_screen" class="screen">
 				<div class="found settings logo-div">
 					<img src="../../img/mic.svg" class="inactive_img settings">

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -10,10 +10,10 @@
             <h1></h1>
         </div>
         <div id="main_content">
-            <canvas id="canvas"></canvas>
             <img class="up_button up_right_button" id="settings_button" show-on show-on-initial src="../../icons/Settings.svg" />
             <img class="up_button up_left_button" button-initial show-on show-on-lyrics show-on-settings src="../../icons/Arrow.svg" style="display:none;"/>
             <div id="initial_screen" class="screen">
+                <canvas id="canvas"></canvas>
                 <div class="audio-bands">
                     <img class="audio-band big 0" src="../../img/audio-band.png" />
                     <img class="audio-band med 1" src="../../img/audio-band.png" />
@@ -32,6 +32,7 @@
             </div>
             <div id="consent_screen" class="screen">
                 <div class="consent-content">
+                    <h1>Consent Required</h1>
                     <p>AudD, LLC certifies that the data processed by the extension and by AudD is not used or transferred for purposes that are unrelated to the extension's core functionality, which is music recognition.</p>
                     <p>When invoked, the extension records up to 12 seconds of audio that's playing on the current browser tab in order to submit it to AudD (music recognition API). The audio is transmitted to AudD servers for music identification. The audio is not stored after the music recognition is complete. AudD might store digital fingerprints of the audio for up to two weeks. The extension, together with the audio, will send its version, the tab title, and the tab URL to AudD. AudD does not share that data with third parties and uses it to prevent abuse of the music recognition API that it provides.</p>
                     <p><a href="https://addons.mozilla.org/en-US/firefox/addon/audd/privacy/" target="_blank">Privacy Policy</a></p>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -272,45 +272,68 @@ function init() {
 	
 	
     var popup_view = PopupView();
-    var recognizer_controller = RecognizerController(popup_view);
-	
-    $('.logo[screen="initial"]').on('click', function() {
-        recognizer_controller.start();
-    });
-    $('.inactive_img.settings').on('click', function() {
-        openScreen("initial");
-        recognizer_controller.start();
-    });
-    $('.up_button[screen="lyrics"]').on('click', function() {
-        openScreen("initial");
-    });
+    var recognizer_controller = null;
+
+    function proceed() {
+        recognizer_controller = RecognizerController(popup_view);
+
+        $('.logo[screen="initial"]').on('click', function() {
+            recognizer_controller.start();
+        });
+        $('.inactive_img.settings').on('click', function() {
+            openScreen("initial");
+            recognizer_controller.start();
+        });
+        $('.up_button[screen="lyrics"]').on('click', function() {
+            openScreen("initial");
+        });
 
 
-    $('#clean-history').on('click', function() {
-        $('#clean-history-confirm').show();
-        $('#clean-history').hide();
-        $('#confirmQuestion').text(chrome.i18n.getMessage("confirmQuestion"));
-        $('#clean-history-yes').text(chrome.i18n.getMessage("yes"));
-        $('#clean-history-no').text(chrome.i18n.getMessage("no"));
-    });
+        $('#clean-history').on('click', function() {
+            $('#clean-history-confirm').show();
+            $('#clean-history').hide();
+            $('#confirmQuestion').text(chrome.i18n.getMessage("confirmQuestion"));
+            $('#clean-history-yes').text(chrome.i18n.getMessage("yes"));
+            $('#clean-history-no').text(chrome.i18n.getMessage("no"));
+        });
 
-    $('#clean-history-yes').on('click', function() {
-        recognizer_controller.clear_history();
-        openScreen("initial");
-        chrome.runtime.sendMessage({cmd: "popup_message_relay", result: {"text": "The history is cleared. Close and open the extension to see the change."}});
-        popup_view.hide_confirm_buttons();
-    });
+        $('#clean-history-yes').on('click', function() {
+            recognizer_controller.clear_history();
+            openScreen("initial");
+            chrome.runtime.sendMessage({cmd: "popup_message_relay", result: {"text": "The history is cleared. Close and open the extension to see the change."}});
+            popup_view.hide_confirm_buttons();
+        });
 
-    $('#clean-history-no').on('click', function() {
-        popup_view.hide_confirm_buttons();
-    });
-    chrome.runtime.sendMessage({cmd: "get_token"});
-	$('#save_settings').on('click', function() {
-		openScreen("initial");
-		chrome.runtime.sendMessage({cmd: "change_settings", api_token: $('#token_input').val(), record_length: $('#recordingLength').val()*100});
-	})
+        $('#clean-history-no').on('click', function() {
+            popup_view.hide_confirm_buttons();
+        });
+        chrome.runtime.sendMessage({cmd: "get_token"});
+        $('#save_settings').on('click', function() {
+            openScreen("initial");
+            chrome.runtime.sendMessage({cmd: "change_settings", api_token: $('#token_input').val(), record_length: $('#recordingLength').val()*100});
+        });
 
-    recognizer_controller.init();
+        recognizer_controller.init();
+    }
+
+    chrome.storage.local.get('consent', function(data) {
+        if (data.consent) {
+            proceed();
+        } else {
+            openScreen('consent');
+            $('#consent_accept').on('click', function() {
+                chrome.storage.local.set({consent: true}, function() {
+                    proceed();
+                    openScreen('initial');
+                });
+            });
+            $('#consent_reject').on('click', function() {
+                if (chrome.management && chrome.management.uninstallSelf) {
+                    chrome.management.uninstallSelf();
+                }
+            });
+        }
+    });
 }
 
 $(window).on('load', function() {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -328,8 +328,8 @@ function init() {
                 });
             });
             $('#consent_reject').on('click', function() {
-                if (chrome.management && chrome.management.uninstallSelf) {
-                    chrome.management.uninstallSelf();
+                if (chrome.management && chrome.management.uninstallSelf) {chrome.management.uninstallSelf({showConfirmDialog: true, dialogMessage: 
+                    "You can click on Uninstall to uninstall extension. Alternatively, you can decide to keep the extension. You would need to consent to our privacy policy to use it."});
                 }
             });
         }


### PR DESCRIPTION
## Summary
- add consent screen with privacy policy text
- style consent screen
- gate extension features behind user consent

## Testing
- `web-ext lint --warnings-as-errors`

------
https://chatgpt.com/codex/tasks/task_e_6877a9b01fa0832694a52961afbb0e7f